### PR TITLE
Apply clang-format

### DIFF
--- a/hls4ml/templates/vitis_accelerator/kernel_wrapper_io_parallel.cpp
+++ b/hls4ml/templates/vitis_accelerator/kernel_wrapper_io_parallel.cpp
@@ -1,46 +1,47 @@
-#include "kernel_wrapper.h"
 #include "firmware/myproject.h"
+#include "kernel_wrapper.h"
 
 static void read_input(const in_buffer_t *in, in_buffer_t (&in_buf)[BATCHSIZE][DATA_SIZE_IN]) {
-  for (int i = 0; i < BATCHSIZE; i++) {
-      #pragma HLS PIPELINE
-      for(int j = 0; j < DATA_SIZE_IN; j++) { 
-        #pragma HLS UNROLL
-        in_buf[i][j] = in[i * DATA_SIZE_IN + j];
-      }
+    for (int i = 0; i < BATCHSIZE; i++) {
+#pragma HLS PIPELINE
+        for (int j = 0; j < DATA_SIZE_IN; j++) {
+#pragma HLS UNROLL
+            in_buf[i][j] = in[i * DATA_SIZE_IN + j];
+        }
     }
 }
-static void run_inference(in_buffer_t (&in_buf)[BATCHSIZE][DATA_SIZE_IN], out_buffer_t (&out_buf)[BATCHSIZE][DATA_SIZE_OUT]) {
-  for (int i = 0; i < BATCHSIZE; i++) {
-      #pragma HLS DATAFLOW
-      myproject(in_buf[i],out_buf[i]);
+static void run_inference(in_buffer_t (&in_buf)[BATCHSIZE][DATA_SIZE_IN],
+                          out_buffer_t (&out_buf)[BATCHSIZE][DATA_SIZE_OUT]) {
+    for (int i = 0; i < BATCHSIZE; i++) {
+#pragma HLS DATAFLOW
+        myproject(in_buf[i], out_buf[i]);
     }
 }
 static void write_result(out_buffer_t *out, out_buffer_t (&out_buf)[BATCHSIZE][DATA_SIZE_OUT]) {
-  for (int i = 0; i < BATCHSIZE; i++) {
-    #pragma HLS PIPELINE
-    for (int j = 0; j < DATA_SIZE_OUT; j++) {
-      #pragma HLS UNROLL
-      out[i * DATA_SIZE_OUT + j] = out_buf[i][j];
+    for (int i = 0; i < BATCHSIZE; i++) {
+#pragma HLS PIPELINE
+        for (int j = 0; j < DATA_SIZE_OUT; j++) {
+#pragma HLS UNROLL
+            out[i * DATA_SIZE_OUT + j] = out_buf[i][j];
+        }
     }
-  }
 }
 
 extern "C" {
-  /**
-    \brief HLS4ML Kernel Implementation 
-    \param in Input Vector
-    \param out Output Vector
+/**
+  \brief HLS4ML Kernel Implementation
+  \param in Input Vector
+  \param out Output Vector
 */
-  void kernel_wrapper(const in_buffer_t *in, out_buffer_t *out) {
+void kernel_wrapper(const in_buffer_t *in, out_buffer_t *out) {
     in_buffer_t in_buf[BATCHSIZE][DATA_SIZE_IN];
     out_buffer_t out_buf[BATCHSIZE][DATA_SIZE_OUT];
-    #pragma HLS ARRAY_RESHAPE   variable=in_buf  complete dim=2
-    #pragma HLS ARRAY_RESHAPE   variable=out_buf complete dim=2
+#pragma HLS ARRAY_RESHAPE variable = in_buf complete dim = 2
+#pragma HLS ARRAY_RESHAPE variable = out_buf complete dim = 2
 
-    #pragma HLS DATAFLOW
+#pragma HLS DATAFLOW
     read_input(in, in_buf);
     run_inference(in_buf, out_buf);
     write_result(out, out_buf);
-  }
+}
 }

--- a/hls4ml/templates/vitis_accelerator/kernel_wrapper_io_stream.cpp
+++ b/hls4ml/templates/vitis_accelerator/kernel_wrapper_io_stream.cpp
@@ -1,43 +1,43 @@
-#include "kernel_wrapper.h"
 #include "firmware/myproject.h"
+#include "kernel_wrapper.h"
 
 static void read_input(const in_buffer_t *in, hls::stream<input_t> &input, int n) {
-  for (int i = 0; i < DATA_SIZE_IN; i++) {
-    #pragma HLS PIPELINE
-    input_t tmp;
-    for (int j = 0; j < NNET_ARRAY_DEPTH; j++) {
-      #pragma HLS UNROLL
-      tmp[j] = in[(n * DATA_SIZE_IN * NNET_ARRAY_DEPTH) + (i * NNET_ARRAY_DEPTH) + j];
+    for (int i = 0; i < DATA_SIZE_IN; i++) {
+#pragma HLS PIPELINE
+        input_t tmp;
+        for (int j = 0; j < NNET_ARRAY_DEPTH; j++) {
+#pragma HLS UNROLL
+            tmp[j] = in[(n * DATA_SIZE_IN * NNET_ARRAY_DEPTH) + (i * NNET_ARRAY_DEPTH) + j];
+        }
+        input << tmp;
     }
-    input << tmp;
-  }
 }
 
 static void write_result(out_buffer_t *out, hls::stream<result_t> &output, int n) {
-  result_t tmp = output.read();
-  for (int i = 0; i < DATA_SIZE_OUT; i++) {
-    #pragma HLS UNROLL
-    out[(n * DATA_SIZE_OUT) + i] = tmp[i];
-  }
+    result_t tmp = output.read();
+    for (int i = 0; i < DATA_SIZE_OUT; i++) {
+#pragma HLS UNROLL
+        out[(n * DATA_SIZE_OUT) + i] = tmp[i];
+    }
 }
 
 extern "C" {
-  /**
-    \brief HLS4ML Kernel Implementation 
-    \param in Input Vector
-    \param out Output Vector
+/**
+  \brief HLS4ML Kernel Implementation
+  \param in Input Vector
+  \param out Output Vector
 */
-  void kernel_wrapper(const in_buffer_t *in, out_buffer_t *out) {
+void kernel_wrapper(const in_buffer_t *in, out_buffer_t *out) {
     hls::stream<input_t> input("input");
     hls::stream<result_t> output("output");
-    #pragma HLS STREAM variable=input depth=DATA_SIZE_IN
-    #pragma HLS STREAM variable=output depth=1
-    
+#pragma HLS STREAM variable = input depth = DATA_SIZE_IN
+#pragma HLS STREAM variable = output depth = 1
+
     for (int n = 0; n < BATCHSIZE; n++) {
-    #pragma HLS DATAFLOW          
-      read_input(in, input, n);
-      myproject(input, output);
-      write_result(out, output, n);
+#pragma HLS DATAFLOW
+        read_input(in, input, n);
+        myproject(input, output);
+        write_result(out, output, n);
     }
-  }
+}
 }

--- a/hls4ml/templates/vitis_accelerator/libs/DdrFpga.hpp
+++ b/hls4ml/templates/vitis_accelerator/libs/DdrFpga.hpp
@@ -2,36 +2,31 @@
 
 #include "FpgaObj.hpp"
 
-template <class V, class W>
-class DdrFpga : public FpgaObj<V, W> {
- public:
+template <class V, class W> class DdrFpga : public FpgaObj<V, W> {
+  public:
     DdrFpga(int kernInputSize, int kernOutputSize, int numCU, int numThreads, int numEpochs)
-        : FpgaObj<V, W>(kernInputSize, kernOutputSize, numCU, numThreads, numEpochs) {
-    }
+        : FpgaObj<V, W>(kernInputSize, kernOutputSize, numCU, numThreads, numEpochs) {}
 
     void allocateHostMemory(int chan_per_port) {
         // Creating Buffer objects in Host memory
         /* ***NOTE*** When creating a Buffer with user pointer (CL_MEM_USE_HOST_PTR), under the hood, user pointer
         is used if it is properly aligned. when not aligned, runtime has no choice but to create
         its own host side Buffer. So it is recommended to use this allocator if user wishes to
-        create Buffer using CL_MEM_USE_HOST_PTR to align user buffer to page boundary. It will 
+        create Buffer using CL_MEM_USE_HOST_PTR to align user buffer to page boundary. It will
         ensure that user buffer is used when user creates Buffer/Mem object with CL_MEM_USE_HOST_PTR */
         size_t vector_size_in_bytes = sizeof(V) * this->_kernInputSize;
         size_t vector_size_out_bytes = sizeof(W) * this->_kernOutputSize;
         for (int ib = 0; ib < this->_numThreads; ib++) {
             for (int ik = 0; ik < this->_numCU; ik++) {
-                cl::Buffer buffer_in_tmp(this->context, 
-                        CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY,
-                        vector_size_in_bytes,
-                        this->source_in.data() + ((ib*this->_numCU + ik) * this->_kernInputSize));
-                cl::Buffer buffer_out_tmp(this->context,
-                        CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY,
-                        vector_size_out_bytes,
-                        this->source_hw_results.data() + ((ib*this->_numCU + ik) * this->_kernOutputSize));
+                cl::Buffer buffer_in_tmp(this->context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_in_bytes,
+                                         this->source_in.data() + ((ib * this->_numCU + ik) * this->_kernInputSize));
+                cl::Buffer buffer_out_tmp(this->context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_out_bytes,
+                                          this->source_hw_results.data() +
+                                              ((ib * this->_numCU + ik) * this->_kernOutputSize));
                 this->buffer_in.push_back(buffer_in_tmp);
                 this->buffer_out.push_back(buffer_out_tmp);
-                this->krnl_xil[ib*this->_numCU + ik].setArg(0, this->buffer_in[ib*this->_numCU + ik]);
-                this->krnl_xil[ib*this->_numCU + ik].setArg(1, this->buffer_out[ib*this->_numCU + ik]);
+                this->krnl_xil[ib * this->_numCU + ik].setArg(0, this->buffer_in[ib * this->_numCU + ik]);
+                this->krnl_xil[ib * this->_numCU + ik].setArg(1, this->buffer_out[ib * this->_numCU + ik]);
             }
         }
     }

--- a/hls4ml/templates/vitis_accelerator/libs/FpgaObj.hpp
+++ b/hls4ml/templates/vitis_accelerator/libs/FpgaObj.hpp
@@ -1,288 +1,276 @@
 #pragma once
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <memory>
 #include <mutex>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include <stdio.h>
 #include <thread>
 #include <vector>
 
 #include "xcl2.hpp"
 
-template <class T, class U>
-class FpgaObj {
- public:
-	std::vector<T,aligned_allocator<T>> source_in;  // Vector containing inputs to all kernels
-	std::vector<U,aligned_allocator<U>> source_hw_results;  // Vector containing all outputs from all kernels
-	cl_int err;  // Stores potential error codes thrown by OpenCL functions
+template <class T, class U> class FpgaObj {
+  public:
+    std::vector<T, aligned_allocator<T>> source_in;         // Vector containing inputs to all kernels
+    std::vector<U, aligned_allocator<U>> source_hw_results; // Vector containing all outputs from all kernels
+    cl_int err;                                             // Stores potential error codes thrown by OpenCL functions
 
-	/**
-	 * \brief Constructor. Reserves and allocates buffers in host memory.
-	 * \param kernInputSize Total size of all input buffers
-	 * \param kernOutputSize Total size of all output buffers
-	 * \param numCU Number of compute units physically instantiated in the FPGA
-	 * \param numThreads Number of threads host cpu will use to drive the FPGA
-	 * \param numEpochs Number of times to loop over the data (for testing purposes)
-	*/
-		FpgaObj(int kernInputSize, int kernOutputSize, int numCU, int numThreads, int numEpochs): 
-			_kernInputSize(kernInputSize),
-			_kernOutputSize(kernOutputSize),
-			_numCU(numCU),
-			_numThreads(numThreads),
-			_numEpochs(numEpochs),
-			ikern(0) {
-				source_in.reserve(_kernInputSize * _numCU * _numThreads);
-				source_hw_results.reserve(_kernOutputSize * _numCU * _numThreads);
-				isFirstRun.reserve(_numCU * _numThreads);
+    /**
+     * \brief Constructor. Reserves and allocates buffers in host memory.
+     * \param kernInputSize Total size of all input buffers
+     * \param kernOutputSize Total size of all output buffers
+     * \param numCU Number of compute units physically instantiated in the FPGA
+     * \param numThreads Number of threads host cpu will use to drive the FPGA
+     * \param numEpochs Number of times to loop over the data (for testing purposes)
+     */
+    FpgaObj(int kernInputSize, int kernOutputSize, int numCU, int numThreads, int numEpochs)
+        : _kernInputSize(kernInputSize), _kernOutputSize(kernOutputSize), _numCU(numCU), _numThreads(numThreads),
+          _numEpochs(numEpochs), ikern(0) {
+        source_in.reserve(_kernInputSize * _numCU * _numThreads);
+        source_hw_results.reserve(_kernOutputSize * _numCU * _numThreads);
+        isFirstRun.reserve(_numCU * _numThreads);
 
-				std::vector<std::mutex> tmp_mtxi(_numCU * _numThreads);
-				mtxi.swap(tmp_mtxi);
-				
-				for(int j = 0 ; j < _kernInputSize * _numCU * _numThreads ; j++){
-					source_in[j] = 0;
-				}
-				for(int j = 0 ; j < _kernOutputSize * _numCU * _numThreads ; j++){
-					source_hw_results[j] = 0;
-				}
-				for (int j = 0 ; j < _numCU * _numThreads ; j++){
-					isFirstRun.push_back(true);
-				}
-		}
+        std::vector<std::mutex> tmp_mtxi(_numCU * _numThreads);
+        mtxi.swap(tmp_mtxi);
 
-	/**
-	 * \brief Initializes OpenCL objects using the given devices and program
-	 * \param devices A vector containing connected devices
-	 * \param bins An OpenCL object containing the binary program that runs on the FPGA
-	*/
-	void initializeOpenCL(std::vector<cl::Device> &devices, cl::Program::Binaries &bins) {
-		// Create OpenCL device and context
-		devices.resize(1);
-		cl::Device clDevice = devices[0];
-		std::string device_name = clDevice.getInfo<CL_DEVICE_NAME>(); 
-		std::cout << "Found Device=" << device_name.c_str() << std::endl;
+        for (int j = 0; j < _kernInputSize * _numCU * _numThreads; j++) {
+            source_in[j] = 0;
+        }
+        for (int j = 0; j < _kernOutputSize * _numCU * _numThreads; j++) {
+            source_hw_results[j] = 0;
+        }
+        for (int j = 0; j < _numCU * _numThreads; j++) {
+            isFirstRun.push_back(true);
+        }
+    }
 
-		cl::Context tmp_context(clDevice);
-		context = tmp_context;
+    /**
+     * \brief Initializes OpenCL objects using the given devices and program
+     * \param devices A vector containing connected devices
+     * \param bins An OpenCL object containing the binary program that runs on the FPGA
+     */
+    void initializeOpenCL(std::vector<cl::Device> &devices, cl::Program::Binaries &bins) {
+        // Create OpenCL device and context
+        devices.resize(1);
+        cl::Device clDevice = devices[0];
+        std::string device_name = clDevice.getInfo<CL_DEVICE_NAME>();
+        std::cout << "Found Device=" << device_name.c_str() << std::endl;
 
-		// Create OpenCL program from binary file
-		cl::Program tmp_program(context, devices, bins);
-		program = tmp_program;
+        cl::Context tmp_context(clDevice);
+        context = tmp_context;
 
-		// Create a OpenCL command queue for each compute unit
-		for (int i = 0; i < _numCU; i++) {
-			cl::CommandQueue q_tmp(context, clDevice, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE);
-			q.push_back(q_tmp);
-		}
+        // Create OpenCL program from binary file
+        cl::Program tmp_program(context, devices, bins);
+        program = tmp_program;
 
-		for (int ib = 0; ib < _numThreads; ib++) {
-			for (int i = 1; i <= _numCU; i++) {
-				// Create virtual kernel objects
-				std::string cu_id = std::to_string(i);
-				std::string krnl_name_full = "kernel_wrapper:{kernel_wrapper_" + cu_id + "}";  // This is Xilinx's format for specifying the Compute Unit a virtual kernel uses
-				printf("Creating virtual kernel object in Thread %d for Compute Unit %d\n", ib, i);
-				cl::Kernel krnl_tmp = cl::Kernel(program, krnl_name_full.c_str(), &err);
-				krnl_xil.push_back(krnl_tmp);
+        // Create a OpenCL command queue for each compute unit
+        for (int i = 0; i < _numCU; i++) {
+            cl::CommandQueue q_tmp(context, clDevice, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE);
+            q.push_back(q_tmp);
+        }
 
-				// Create Event objects
-				cl::Event tmp_write = cl::Event();
-				cl::Event tmp_kern = cl::Event();
-				cl::Event tmp_read = cl::Event();
-				write_event.push_back(tmp_write);
-				kern_event.push_back(tmp_kern);
-				read_event.push_back(tmp_read);
+        for (int ib = 0; ib < _numThreads; ib++) {
+            for (int i = 1; i <= _numCU; i++) {
+                // Create virtual kernel objects
+                std::string cu_id = std::to_string(i);
+                std::string krnl_name_full =
+                    "kernel_wrapper:{kernel_wrapper_" + cu_id +
+                    "}"; // This is Xilinx's format for specifying the Compute Unit a virtual kernel uses
+                printf("Creating virtual kernel object in Thread %d for Compute Unit %d\n", ib, i);
+                cl::Kernel krnl_tmp = cl::Kernel(program, krnl_name_full.c_str(), &err);
+                krnl_xil.push_back(krnl_tmp);
 
-				std::vector<cl::Event> tmp_write_vec;
-				std::vector<cl::Event> tmp_kern_vec;
-				tmp_write_vec.reserve(1);
-				tmp_kern_vec.reserve(1);
-				writeList.push_back(tmp_write_vec);
-				kernList.push_back(tmp_kern_vec);
-			}
-		}
-	}
+                // Create Event objects
+                cl::Event tmp_write = cl::Event();
+                cl::Event tmp_kern = cl::Event();
+                cl::Event tmp_read = cl::Event();
+                write_event.push_back(tmp_write);
+                kern_event.push_back(tmp_kern);
+                read_event.push_back(tmp_read);
 
-	/**
-	 * \brief Creates OpenCL pointer objects and buffers for device inputs and outputs. Implemented by subclasses
-	*/
-	virtual void allocateHostMemory(int chan_per_port) = 0;
+                std::vector<cl::Event> tmp_write_vec;
+                std::vector<cl::Event> tmp_kern_vec;
+                tmp_write_vec.reserve(1);
+                tmp_kern_vec.reserve(1);
+                writeList.push_back(tmp_write_vec);
+                kernList.push_back(tmp_kern_vec);
+            }
+        }
+    }
 
-	/**
-	 * \brief Completes all enqueued operations
-	*/
-	void finishRun() {
-		for (int i = 0 ; i < _numCU ; i++){
-			OCL_CHECK(err, err = q[i].finish());
-		}
-	}
+    /**
+     * \brief Creates OpenCL pointer objects and buffers for device inputs and outputs. Implemented by subclasses
+     */
+    virtual void allocateHostMemory(int chan_per_port) = 0;
 
-	/**
-	 * \brief Migrates input to FPGA , executes kernels, and migrates output to host memory. Run this function in numThreads different threads
-	*/
-	void runFPGA() {
-		for (int i = 0 ; i < _numCU * _numEpochs; i++){
-			auto ikf = get_info_lock();
-			int ikb = ikf.first;
-			int ik = ikb % _numCU ;
-			bool firstRun = ikf.second;
-		
-			get_ilock(ikb);
-			// Copy input data to device global memory
-			if (!firstRun) {
-				OCL_CHECK(err, err = read_event[ikb].wait());
-			}
-			OCL_CHECK(err,
-						err =
-							q[ik].enqueueMigrateMemObjects({buffer_in[ikb]},
-														0 /* 0 means from host*/,
-														NULL,
-														&(write_event[ikb])));
-			writeList[ikb].push_back(write_event[ikb]);
-			//Launch the kernel
-			OCL_CHECK(err,
-						err = q[ik].enqueueNDRangeKernel(
-							krnl_xil[ikb], 0, 1, 1, &(writeList[ikb]), &(kern_event[ikb])));
+    /**
+     * \brief Completes all enqueued operations
+     */
+    void finishRun() {
+        for (int i = 0; i < _numCU; i++) {
+            OCL_CHECK(err, err = q[i].finish());
+        }
+    }
 
-			kernList[ikb].push_back(kern_event[ikb]);
-			OCL_CHECK(err,
-						err = q[ik].enqueueMigrateMemObjects({buffer_out[ikb]},
-														CL_MIGRATE_MEM_OBJECT_HOST,
-														&(kernList[ikb]),
-														&(read_event[ikb])));
-			release_ilock(ikb);
-		
-			OCL_CHECK(err, err = kern_event[ikb].wait());
-			OCL_CHECK(err, err = read_event[ikb].wait());
-		}
-	}
+    /**
+     * \brief Migrates input to FPGA , executes kernels, and migrates output to host memory. Run this function in numThreads
+     * different threads
+     */
+    void runFPGA() {
+        for (int i = 0; i < _numCU * _numEpochs; i++) {
+            auto ikf = get_info_lock();
+            int ikb = ikf.first;
+            int ik = ikb % _numCU;
+            bool firstRun = ikf.second;
 
-	protected:
-	int _kernInputSize;
-	int _kernOutputSize;
-	int _numCU;
-	int _numThreads;
-	int _numEpochs;
+            get_ilock(ikb);
+            // Copy input data to device global memory
+            if (!firstRun) {
+                OCL_CHECK(err, err = read_event[ikb].wait());
+            }
+            OCL_CHECK(err, err = q[ik].enqueueMigrateMemObjects({buffer_in[ikb]}, 0 /* 0 means from host*/, NULL,
+                                                                &(write_event[ikb])));
+            writeList[ikb].push_back(write_event[ikb]);
+            // Launch the kernel
+            OCL_CHECK(err, err = q[ik].enqueueNDRangeKernel(krnl_xil[ikb], 0, 1, 1, &(writeList[ikb]), &(kern_event[ikb])));
 
-	int ikern;  // Counter tracking which virtual kernel is being run
-	std::vector<bool> isFirstRun;  // Vector tracking whether each virtual kernel is being run for the first time
-	mutable std::mutex mtx;  // Mutex for ikern, isFirstRun, and get_info_lock()
-	mutable std::vector<std::mutex> mtxi;  // Mutexes for each virtual kernel and associate resources
+            kernList[ikb].push_back(kern_event[ikb]);
+            OCL_CHECK(err, err = q[ik].enqueueMigrateMemObjects({buffer_out[ikb]}, CL_MIGRATE_MEM_OBJECT_HOST,
+                                                                &(kernList[ikb]), &(read_event[ikb])));
+            release_ilock(ikb);
 
-	cl::Program program;  // Object containing the Program (built from kernel_wrapper.cpp) that runs on each physical compute unit
-	cl::Context context;  // Object containing the Device Context
-	std::vector<cl::CommandQueue> q;  // Vector containing Command Queue objects controlling physical compute units
-	std::vector<cl::Kernel> krnl_xil;  // Vector containing virtual kernel objects
-	std::vector<cl_mem_ext_ptr_t> buf_in_ext;  // Vector containing Pointer objects that map host memory to FPGA input.
-	std::vector<cl_mem_ext_ptr_t> buf_out_ext;  // Vector containing Pointer objects that map host memory to FPGA output.
-	std::vector<cl::Buffer> buffer_in;  // Vector containing Buffer objects for FPGA inputs, corresponding to physical compute units
-	std::vector<cl::Buffer> buffer_out;  // Vector containing Buffer objects for FPGA outputs, corresponding to physical compute units
-	std::vector<cl::Event> write_event;  // Vector of Event objects, used as flags indicating completion of transferring inputs to physical compute units
-	std::vector<cl::Event> kern_event;  // Vector of Event objects, used as flags indicating completion of computation by physical compute units
-	std::vector<cl::Event> read_event;  // Vector of Event objects, used as flags indicating completion of transferring outputs from physical compute units
-	std::vector<std::vector<cl::Event>> writeList;  // enqueueNDRangeKernel requires a vector of Event objects and checks each for completion
-	std::vector<std::vector<cl::Event>> kernList;  // enqueueMigrateMemObjects requires a vector of Event objects and checks each for completion
+            OCL_CHECK(err, err = kern_event[ikb].wait());
+            OCL_CHECK(err, err = read_event[ikb].wait());
+        }
+    }
 
-	/**
-	 * \brief Tracks the index of the virtual kernel being run, and whether it is being run for the first time
-	 * \return Returns a pair: (index, first run indicator)
-	*/
-	std::pair<int,bool> get_info_lock() {
-		int i;
-		bool first;
-		mtx.lock();
-		i = ikern++;
-		if (ikern == _numCU * _numThreads) {
-			ikern = 0;
-		}
-		first = isFirstRun[i];
-		if (first) {
-			isFirstRun[i] = false;
-		}
-		mtx.unlock();
-		return std::make_pair(i,first);
-	}
+  protected:
+    int _kernInputSize;
+    int _kernOutputSize;
+    int _numCU;
+    int _numThreads;
+    int _numEpochs;
 
-	/**
-	 * \brief Locks the appropriate mutex to ensure thread safety for the virtual kernel being run
-	 * \param ik The index of the virtual kernel being run
-	*/
-	void get_ilock(int ik) {
-		mtxi[ik].lock();
-	}
+    int ikern;                            // Counter tracking which virtual kernel is being run
+    std::vector<bool> isFirstRun;         // Vector tracking whether each virtual kernel is being run for the first time
+    mutable std::mutex mtx;               // Mutex for ikern, isFirstRun, and get_info_lock()
+    mutable std::vector<std::mutex> mtxi; // Mutexes for each virtual kernel and associate resources
 
-	/**
-	 * \brief Unlocks the appropriate mutex for the virtual kernel that has finished running
-	 * \param ik The index of the virtual kernel that has finished running
-	*/
-	void release_ilock(int ik) {
-		mtxi[ik].unlock();
-	}
+    cl::Program
+        program; // Object containing the Program (built from kernel_wrapper.cpp) that runs on each physical compute unit
+    cl::Context context;                       // Object containing the Device Context
+    std::vector<cl::CommandQueue> q;           // Vector containing Command Queue objects controlling physical compute units
+    std::vector<cl::Kernel> krnl_xil;          // Vector containing virtual kernel objects
+    std::vector<cl_mem_ext_ptr_t> buf_in_ext;  // Vector containing Pointer objects that map host memory to FPGA input.
+    std::vector<cl_mem_ext_ptr_t> buf_out_ext; // Vector containing Pointer objects that map host memory to FPGA output.
+    std::vector<cl::Buffer>
+        buffer_in; // Vector containing Buffer objects for FPGA inputs, corresponding to physical compute units
+    std::vector<cl::Buffer>
+        buffer_out; // Vector containing Buffer objects for FPGA outputs, corresponding to physical compute units
+    std::vector<cl::Event> write_event; // Vector of Event objects, used as flags indicating completion of transferring
+                                        // inputs to physical compute units
+    std::vector<cl::Event>
+        kern_event; // Vector of Event objects, used as flags indicating completion of computation by physical compute units
+    std::vector<cl::Event> read_event; // Vector of Event objects, used as flags indicating completion of transferring
+                                       // outputs from physical compute units
+    std::vector<std::vector<cl::Event>>
+        writeList; // enqueueNDRangeKernel requires a vector of Event objects and checks each for completion
+    std::vector<std::vector<cl::Event>>
+        kernList; // enqueueMigrateMemObjects requires a vector of Event objects and checks each for completion
 
-	/**
-	* \brief **UNTESTED** Callback function for Event objects that prints a description of the operation performed by the OpenCL runtime.
-	*/ 
-	void event_cb(cl_event event1, cl_int cmd_status, void *data) {
-		cl_int err;
-		cl_command_type command;
-		cl::Event event(event1, true);
-		OCL_CHECK(err, err = event.getInfo(CL_EVENT_COMMAND_TYPE, &command));
-		cl_int status;
-		OCL_CHECK(err,
-				err = event.getInfo(CL_EVENT_COMMAND_EXECUTION_STATUS, &status));
-		const char *command_str;
-		const char *status_str;
-		switch (command) {
-		case CL_COMMAND_READ_BUFFER:
-			command_str = "buffer read";
-			break;
-		case CL_COMMAND_WRITE_BUFFER:
-			command_str = "buffer write";
-			break;
-		case CL_COMMAND_NDRANGE_KERNEL:
-			command_str = "kernel";
-			break;
-		case CL_COMMAND_MAP_BUFFER:
-			command_str = "kernel";
-			break;
-		case CL_COMMAND_COPY_BUFFER:
-			command_str = "kernel";
-			break;
-		case CL_COMMAND_MIGRATE_MEM_OBJECTS:
-			command_str = "buffer migrate";
-			break;
-		default:
-			command_str = "unknown";
-		}
-		switch (status) {
-		case CL_QUEUED:
-			status_str = "Queued";
-			break;
-		case CL_SUBMITTED:
-			status_str = "Submitted";
-			break;
-		case CL_RUNNING:
-			status_str = "Executing";
-			break;
-		case CL_COMPLETE:
-			status_str = "Completed";
-			break;
-		}
-		printf("[%s]: %s %s\n",
-			reinterpret_cast<char *>(data),
-			status_str,
-			command_str);
-		fflush(stdout);
-	}
+    /**
+     * \brief Tracks the index of the virtual kernel being run, and whether it is being run for the first time
+     * \return Returns a pair: (index, first run indicator)
+     */
+    std::pair<int, bool> get_info_lock() {
+        int i;
+        bool first;
+        mtx.lock();
+        i = ikern++;
+        if (ikern == _numCU * _numThreads) {
+            ikern = 0;
+        }
+        first = isFirstRun[i];
+        if (first) {
+            isFirstRun[i] = false;
+        }
+        mtx.unlock();
+        return std::make_pair(i, first);
+    }
 
-	/**
-	 * \brief **UNTESTED** Sets event_cb() as an Event's callback function.
-	*/
-	void set_callback(const char *queue_name, cl::Event event) {
-		cl_int err;
-		OCL_CHECK(err,
-				err =
-					event.setCallback(CL_COMPLETE, event_cb, (void *)queue_name));
-	}
+    /**
+     * \brief Locks the appropriate mutex to ensure thread safety for the virtual kernel being run
+     * \param ik The index of the virtual kernel being run
+     */
+    void get_ilock(int ik) { mtxi[ik].lock(); }
+
+    /**
+     * \brief Unlocks the appropriate mutex for the virtual kernel that has finished running
+     * \param ik The index of the virtual kernel that has finished running
+     */
+    void release_ilock(int ik) { mtxi[ik].unlock(); }
+
+    /**
+     * \brief **UNTESTED** Callback function for Event objects that prints a description of the operation performed by the
+     * OpenCL runtime.
+     */
+    void event_cb(cl_event event1, cl_int cmd_status, void *data) {
+        cl_int err;
+        cl_command_type command;
+        cl::Event event(event1, true);
+        OCL_CHECK(err, err = event.getInfo(CL_EVENT_COMMAND_TYPE, &command));
+        cl_int status;
+        OCL_CHECK(err, err = event.getInfo(CL_EVENT_COMMAND_EXECUTION_STATUS, &status));
+        const char *command_str;
+        const char *status_str;
+        switch (command) {
+        case CL_COMMAND_READ_BUFFER:
+            command_str = "buffer read";
+            break;
+        case CL_COMMAND_WRITE_BUFFER:
+            command_str = "buffer write";
+            break;
+        case CL_COMMAND_NDRANGE_KERNEL:
+            command_str = "kernel";
+            break;
+        case CL_COMMAND_MAP_BUFFER:
+            command_str = "kernel";
+            break;
+        case CL_COMMAND_COPY_BUFFER:
+            command_str = "kernel";
+            break;
+        case CL_COMMAND_MIGRATE_MEM_OBJECTS:
+            command_str = "buffer migrate";
+            break;
+        default:
+            command_str = "unknown";
+        }
+        switch (status) {
+        case CL_QUEUED:
+            status_str = "Queued";
+            break;
+        case CL_SUBMITTED:
+            status_str = "Submitted";
+            break;
+        case CL_RUNNING:
+            status_str = "Executing";
+            break;
+        case CL_COMPLETE:
+            status_str = "Completed";
+            break;
+        }
+        printf("[%s]: %s %s\n", reinterpret_cast<char *>(data), status_str, command_str);
+        fflush(stdout);
+    }
+
+    /**
+     * \brief **UNTESTED** Sets event_cb() as an Event's callback function.
+     */
+    void set_callback(const char *queue_name, cl::Event event) {
+        cl_int err;
+        OCL_CHECK(err, err = event.setCallback(CL_COMPLETE, event_cb, (void *)queue_name));
+    }
 };

--- a/hls4ml/templates/vitis_accelerator/libs/HbmFpga.hpp
+++ b/hls4ml/templates/vitis_accelerator/libs/HbmFpga.hpp
@@ -5,18 +5,16 @@
 // HBM Pseudo-channel(PC) requirements
 #define MAX_HBM_PC_COUNT 32
 #define PC_NAME(n) n | XCL_MEM_TOPOLOGY
-const int pc[MAX_HBM_PC_COUNT] = {
-    PC_NAME(0),  PC_NAME(1),  PC_NAME(2),  PC_NAME(3),  PC_NAME(4),  PC_NAME(5),  PC_NAME(6),  PC_NAME(7),
-    PC_NAME(8),  PC_NAME(9),  PC_NAME(10), PC_NAME(11), PC_NAME(12), PC_NAME(13), PC_NAME(14), PC_NAME(15),
-    PC_NAME(16), PC_NAME(17), PC_NAME(18), PC_NAME(19), PC_NAME(20), PC_NAME(21), PC_NAME(22), PC_NAME(23),
-    PC_NAME(24), PC_NAME(25), PC_NAME(26), PC_NAME(27), PC_NAME(28), PC_NAME(29), PC_NAME(30), PC_NAME(31)};
+const int pc[MAX_HBM_PC_COUNT] = {PC_NAME(0),  PC_NAME(1),  PC_NAME(2),  PC_NAME(3),  PC_NAME(4),  PC_NAME(5),  PC_NAME(6),
+                                  PC_NAME(7),  PC_NAME(8),  PC_NAME(9),  PC_NAME(10), PC_NAME(11), PC_NAME(12), PC_NAME(13),
+                                  PC_NAME(14), PC_NAME(15), PC_NAME(16), PC_NAME(17), PC_NAME(18), PC_NAME(19), PC_NAME(20),
+                                  PC_NAME(21), PC_NAME(22), PC_NAME(23), PC_NAME(24), PC_NAME(25), PC_NAME(26), PC_NAME(27),
+                                  PC_NAME(28), PC_NAME(29), PC_NAME(30), PC_NAME(31)};
 
-template <class V, class W>
-class HbmFpga : public FpgaObj<V, W> {
- public:
+template <class V, class W> class HbmFpga : public FpgaObj<V, W> {
+  public:
     HbmFpga(int kernInputSize, int kernOutputSize, int numCU, int numThreads, int numEpochs)
-        : FpgaObj<V, W>(kernInputSize, kernOutputSize, numCU, numThreads, numEpochs) {
-    }
+        : FpgaObj<V, W>(kernInputSize, kernOutputSize, numCU, numThreads, numEpochs) {}
 
     void allocateHostMemory(int chan_per_port) {
         // Create Pointer objects for the ports for each virtual compute unit
@@ -24,25 +22,25 @@ class HbmFpga : public FpgaObj<V, W> {
         for (int ib = 0; ib < this->_numThreads; ib++) {
             for (int ik = 0; ik < this->_numCU; ik++) {
                 cl_mem_ext_ptr_t buf_in_ext_tmp;
-                buf_in_ext_tmp.obj = this->source_in.data() + ((ib*this->_numCU + ik) * this->_kernInputSize);
+                buf_in_ext_tmp.obj = this->source_in.data() + ((ib * this->_numCU + ik) * this->_kernInputSize);
                 buf_in_ext_tmp.param = 0;
                 int in_flags = 0;
                 for (int i = 0; i < chan_per_port; i++) {
                     in_flags |= pc[(ik * 2 * 4) + i];
                 }
                 buf_in_ext_tmp.flags = in_flags;
-                
+
                 this->buf_in_ext.push_back(buf_in_ext_tmp);
 
                 cl_mem_ext_ptr_t buf_out_ext_tmp;
-                buf_out_ext_tmp.obj = this->source_hw_results.data() + ((ib*this->_numCU + ik) * this->_kernOutputSize);
+                buf_out_ext_tmp.obj = this->source_hw_results.data() + ((ib * this->_numCU + ik) * this->_kernOutputSize);
                 buf_out_ext_tmp.param = 0;
                 int out_flags = 0;
                 for (int i = 0; i < chan_per_port; i++) {
                     out_flags |= pc[(ik * 2 * 4) + chan_per_port + i];
                 }
                 buf_out_ext_tmp.flags = out_flags;
-                
+
                 this->buf_out_ext.push_back(buf_out_ext_tmp);
             }
         }
@@ -51,24 +49,20 @@ class HbmFpga : public FpgaObj<V, W> {
         /* ***NOTE*** When creating a Buffer with user pointer (CL_MEM_USE_HOST_PTR), under the hood, user pointer
         is used if it is properly aligned. when not aligned, runtime has no choice but to create
         its own host side Buffer. So it is recommended to use this allocator if user wishes to
-        create Buffer using CL_MEM_USE_HOST_PTR to align user buffer to page boundary. It will 
+        create Buffer using CL_MEM_USE_HOST_PTR to align user buffer to page boundary. It will
         ensure that user buffer is used when user creates Buffer/Mem object with CL_MEM_USE_HOST_PTR */
         size_t vector_size_in_bytes = sizeof(V) * this->_kernInputSize;
         size_t vector_size_out_bytes = sizeof(W) * this->_kernOutputSize;
         for (int ib = 0; ib < this->_numThreads; ib++) {
             for (int ik = 0; ik < this->_numCU; ik++) {
-                cl::Buffer buffer_in_tmp(this->context, 
-                        CL_MEM_USE_HOST_PTR | CL_MEM_EXT_PTR_XILINX | CL_MEM_READ_ONLY,
-                        vector_size_in_bytes,
-                        &(this->buf_in_ext[ib*this->_numCU + ik]));
-                cl::Buffer buffer_out_tmp(this->context,
-                        CL_MEM_USE_HOST_PTR | CL_MEM_EXT_PTR_XILINX | CL_MEM_WRITE_ONLY,
-                        vector_size_out_bytes,
-                        &(this->buf_out_ext[ib*this->_numCU + ik]));
+                cl::Buffer buffer_in_tmp(this->context, CL_MEM_USE_HOST_PTR | CL_MEM_EXT_PTR_XILINX | CL_MEM_READ_ONLY,
+                                         vector_size_in_bytes, &(this->buf_in_ext[ib * this->_numCU + ik]));
+                cl::Buffer buffer_out_tmp(this->context, CL_MEM_USE_HOST_PTR | CL_MEM_EXT_PTR_XILINX | CL_MEM_WRITE_ONLY,
+                                          vector_size_out_bytes, &(this->buf_out_ext[ib * this->_numCU + ik]));
                 this->buffer_in.push_back(buffer_in_tmp);
                 this->buffer_out.push_back(buffer_out_tmp);
-                this->krnl_xil[ib*this->_numCU + ik].setArg(0, this->buffer_in[ib*this->_numCU + ik]);
-                this->krnl_xil[ib*this->_numCU + ik].setArg(1, this->buffer_out[ib*this->_numCU + ik]);
+                this->krnl_xil[ib * this->_numCU + ik].setArg(0, this->buffer_in[ib * this->_numCU + ik]);
+                this->krnl_xil[ib * this->_numCU + ik].setArg(1, this->buffer_out[ib * this->_numCU + ik]);
             }
         }
     }

--- a/hls4ml/templates/vitis_accelerator/libs/xcl2.cpp
+++ b/hls4ml/templates/vitis_accelerator/libs/xcl2.cpp
@@ -1,25 +1,25 @@
 /**
-* Copyright (C) 2019-2021 Xilinx, Inc
-*
-* Licensed under the Apache License, Version 2.0 (the "License"). You may
-* not use this file except in compliance with the License. A copy of the
-* License is located at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (C) 2019-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 #include "xcl2.hpp"
 #include <climits>
-#include <sys/stat.h>
-#include <string>
 #include <iomanip>
 #include <sstream>
+#include <string>
+#include <sys/stat.h>
 #if defined(_WINDOWS)
 #include <io.h>
 #else
@@ -27,7 +27,7 @@
 #endif
 
 namespace xcl {
-std::vector<cl::Device> get_devices(const std::string& vendor_name) {
+std::vector<cl::Device> get_devices(const std::string &vendor_name) {
     size_t i;
     cl_int err;
     std::vector<cl::Platform> platforms;
@@ -58,11 +58,9 @@ std::vector<cl::Device> get_devices(const std::string& vendor_name) {
     return devices;
 }
 
-std::vector<cl::Device> get_xil_devices() {
-    return get_devices("Xilinx");
-}
+std::vector<cl::Device> get_xil_devices() { return get_devices("Xilinx"); }
 
-cl::Device find_device_bdf(const std::vector<cl::Device>& devices, const std::string& bdf) {
+cl::Device find_device_bdf(const std::vector<cl::Device> &devices, const std::string &bdf) {
     char device_bdf[20];
     cl_int err;
     cl::Device device;
@@ -81,7 +79,7 @@ cl::Device find_device_bdf(const std::vector<cl::Device>& devices, const std::st
     }
     return device;
 }
-cl_device_id find_device_bdf_c(cl_device_id* devices, const std::string& bdf, cl_uint device_count) {
+cl_device_id find_device_bdf_c(cl_device_id *devices, const std::string &bdf, cl_uint device_count) {
     char device_bdf[20];
     cl_int err;
     cl_device_id device;
@@ -104,9 +102,9 @@ cl_device_id find_device_bdf_c(cl_device_id* devices, const std::string& bdf, cl
     }
     return device;
 }
-std::vector<unsigned char> read_binary_file(const std::string& xclbin_file_name) {
+std::vector<unsigned char> read_binary_file(const std::string &xclbin_file_name) {
     std::cout << "INFO: Reading " << xclbin_file_name << std::endl;
-    FILE* fp;
+    FILE *fp;
     if ((fp = fopen(xclbin_file_name.c_str(), "r")) == nullptr) {
         printf("ERROR: %s xclbin not available please build\n", xclbin_file_name.c_str());
         exit(EXIT_FAILURE);
@@ -119,13 +117,13 @@ std::vector<unsigned char> read_binary_file(const std::string& xclbin_file_name)
     bin_file.seekg(0, bin_file.beg);
     std::vector<unsigned char> buf;
     buf.resize(nb);
-    bin_file.read(reinterpret_cast<char*>(buf.data()), nb);
+    bin_file.read(reinterpret_cast<char *>(buf.data()), nb);
     return buf;
 }
 
 bool is_emulation() {
     bool ret = false;
-    char* xcl_mode = getenv("XCL_EMULATION_MODE");
+    char *xcl_mode = getenv("XCL_EMULATION_MODE");
     if (xcl_mode != nullptr) {
         ret = true;
     }
@@ -134,7 +132,7 @@ bool is_emulation() {
 
 bool is_hw_emulation() {
     bool ret = false;
-    char* xcl_mode = getenv("XCL_EMULATION_MODE");
+    char *xcl_mode = getenv("XCL_EMULATION_MODE");
     if ((xcl_mode != nullptr) && !strcmp(xcl_mode, "hw_emu")) {
         ret = true;
     }
@@ -148,7 +146,7 @@ double round_off(double n) {
 }
 
 std::string convert_size(size_t size) {
-    static const char* SIZES[] = {"B", "KB", "MB", "GB"};
+    static const char *SIZES[] = {"B", "KB", "MB", "GB"};
     uint32_t div = 0;
     size_t rem = 0;
 
@@ -168,8 +166,8 @@ std::string convert_size(size_t size) {
     return result;
 }
 
-bool is_xpr_device(const char* device_name) {
-    const char* output = strstr(device_name, "xpr");
+bool is_xpr_device(const char *device_name) {
+    const char *output = strstr(device_name, "xpr");
 
     if (output == nullptr) {
         return false;

--- a/hls4ml/templates/vitis_accelerator/libs/xcl2.hpp
+++ b/hls4ml/templates/vitis_accelerator/libs/xcl2.hpp
@@ -1,18 +1,18 @@
 /**
-* Copyright (C) 2019-2021 Xilinx, Inc
-*
-* Licensed under the Apache License, Version 2.0 (the "License"). You may
-* not use this file except in compliance with the License. A copy of the
-* License is located at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (C) 2019-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 #pragma once
 
@@ -23,11 +23,11 @@
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 
 // OCL_CHECK doesn't work if call has templatized function call
-#define OCL_CHECK(error, call)                                                                   \
-    call;                                                                                        \
-    if (error != CL_SUCCESS) {                                                                   \
-        printf("%s:%d Error calling " #call ", error code is: %d\n", __FILE__, __LINE__, error); \
-        exit(EXIT_FAILURE);                                                                      \
+#define OCL_CHECK(error, call)                                                                                              \
+    call;                                                                                                                   \
+    if (error != CL_SUCCESS) {                                                                                              \
+        printf("%s:%d Error calling " #call ", error code is: %d\n", __FILE__, __LINE__, error);                            \
+        exit(EXIT_FAILURE);                                                                                                 \
     }
 
 #include <CL/cl2.hpp>
@@ -48,19 +48,17 @@
 // the
 // page boundary. It will ensure that user buffer will be used when user create
 // Buffer/Mem Object with CL_MEM_USE_HOST_PTR.
-template <typename T>
-struct aligned_allocator {
+template <typename T> struct aligned_allocator {
     using value_type = T;
 
     aligned_allocator() {}
 
-    aligned_allocator(const aligned_allocator&) {}
+    aligned_allocator(const aligned_allocator &) {}
 
-    template <typename U>
-    aligned_allocator(const aligned_allocator<U>&) {}
+    template <typename U> aligned_allocator(const aligned_allocator<U> &) {}
 
-    T* allocate(std::size_t num) {
-        void* ptr = nullptr;
+    T *allocate(std::size_t num) {
+        void *ptr = nullptr;
 
 #if defined(_WINDOWS)
         {
@@ -72,12 +70,13 @@ struct aligned_allocator {
         }
 #else
         {
-            if (posix_memalign(&ptr, 4096, num * sizeof(T))) throw std::bad_alloc();
+            if (posix_memalign(&ptr, 4096, num * sizeof(T)))
+                throw std::bad_alloc();
         }
 #endif
-        return reinterpret_cast<T*>(ptr);
+        return reinterpret_cast<T *>(ptr);
     }
-    void deallocate(T* p, std::size_t num) {
+    void deallocate(T *p, std::size_t num) {
 #if defined(_WINDOWS)
         _aligned_free(p);
 #else
@@ -88,31 +87,31 @@ struct aligned_allocator {
 
 namespace xcl {
 std::vector<cl::Device> get_xil_devices();
-std::vector<cl::Device> get_devices(const std::string& vendor_name);
-cl::Device find_device_bdf(const std::vector<cl::Device>& devices, const std::string& bdf);
-cl_device_id find_device_bdf_c(cl_device_id* devices, const std::string& bdf, cl_uint dev_count);
+std::vector<cl::Device> get_devices(const std::string &vendor_name);
+cl::Device find_device_bdf(const std::vector<cl::Device> &devices, const std::string &bdf);
+cl_device_id find_device_bdf_c(cl_device_id *devices, const std::string &bdf, cl_uint dev_count);
 std::string convert_size(size_t size);
-std::vector<unsigned char> read_binary_file(const std::string& xclbin_file_name);
+std::vector<unsigned char> read_binary_file(const std::string &xclbin_file_name);
 bool is_emulation();
 bool is_hw_emulation();
-bool is_xpr_device(const char* device_name);
+bool is_xpr_device(const char *device_name);
 class P2P {
-   public:
+  public:
     static decltype(&xclGetMemObjectFd) getMemObjectFd;
     static decltype(&xclGetMemObjectFromFd) getMemObjectFromFd;
-    static void init(const cl_platform_id& platform) {
-        void* bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetMemObjectFd");
+    static void init(const cl_platform_id &platform) {
+        void *bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetMemObjectFd");
         getMemObjectFd = (decltype(&xclGetMemObjectFd))bar;
         bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetMemObjectFromFd");
         getMemObjectFromFd = (decltype(&xclGetMemObjectFromFd))bar;
     }
 };
 class Ext {
-   public:
+  public:
     static decltype(&xclGetComputeUnitInfo) getComputeUnitInfo;
-    static void init(const cl_platform_id& platform) {
-        void* bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetComputeUnitInfo");
+    static void init(const cl_platform_id &platform) {
+        void *bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetComputeUnitInfo");
         getComputeUnitInfo = (decltype(&xclGetComputeUnitInfo))bar;
     }
 };
-}
+} // namespace xcl

--- a/hls4ml/templates/vitis_accelerator/myproject_host_cl.cpp
+++ b/hls4ml/templates/vitis_accelerator/myproject_host_cl.cpp
@@ -1,24 +1,21 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <thread>
 #include <vector>
 
-#include "kernel_wrapper.h"
+#include "DdrFpga.hpp"
 #include "FpgaObj.hpp"
 #include "HbmFpga.hpp"
-#include "DdrFpga.hpp"
+#include "kernel_wrapper.h"
 #include "xcl2.hpp"
 
 #define STRINGIFY(var) #var
 #define EXPAND_STRING(var) STRINGIFY(var)
 
-
-void runFPGAHelper(FpgaObj<in_buffer_t, out_buffer_t> &fpga) {
-    fpga.runFPGA();
-}
+void runFPGAHelper(FpgaObj<in_buffer_t, out_buffer_t> &fpga) { fpga.runFPGA(); }
 
 int main(int argc, char **argv) {
     if (argc != 2) {
@@ -27,15 +24,17 @@ int main(int argc, char **argv) {
     }
     std::string xclbinFilename = argv[1];
 
-    /*FPGATYPE*/<in_buffer_t, out_buffer_t> fpga(BATCHSIZE * INSTREAMSIZE, BATCHSIZE * OUTSTREAMSIZE, NUM_CU, NUM_THREAD, 10); 
+    /*FPGATYPE*/<in_buffer_t, out_buffer_t> fpga(BATCHSIZE * INSTREAMSIZE, BATCHSIZE * OUTSTREAMSIZE, NUM_CU, NUM_THREAD,
+                                                 10);
 
-    std::vector<cl::Device> devices = xcl::get_xil_devices();  // Utility API that finds xilinx platforms and return a list of devices connected to Xilinx platforms
-    auto fileBuf = xcl::read_binary_file(xclbinFilename);  // Load xclbin
+    std::vector<cl::Device> devices = xcl::get_xil_devices(); // Utility API that finds xilinx platforms and return a list of
+                                                              // devices connected to Xilinx platforms
+    auto fileBuf = xcl::read_binary_file(xclbinFilename);     // Load xclbin
     cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
     fpga.initializeOpenCL(devices, bins);
 
     fpga.allocateHostMemory(NUM_CHANNEL);
-      
+
     std::cout << "Loading input data from tb_data/tb_input_features.dat" << std::endl;
     std::ifstream fin("tb_data/tb_input_features.dat");
     if (!fin.is_open()) {
@@ -49,7 +48,7 @@ int main(int argc, char **argv) {
             if (num_inputs % 100 == 0) {
                 std::cout << "Processing input " << num_inputs << std::endl;
             }
-            std::stringstream in(iline); 
+            std::stringstream in(iline);
             std::string token;
             while (in >> token) {
                 in_buffer_t tmp = stof(token);
@@ -81,15 +80,15 @@ int main(int argc, char **argv) {
     fpga.finishRun();
 
     auto ts_end = std::chrono::system_clock::now();
-    float throughput = (float(BATCHSIZE* NUM_CU * NUM_THREAD * 10 ) /
-            float(std::chrono::duration_cast<std::chrono::nanoseconds>(ts_end - ts_start).count())) *
-            1000000000.;
-    std::cout << "Throughput = " << throughput <<" predictions/second\n" << std::endl;
+    float throughput = (float(BATCHSIZE * NUM_CU * NUM_THREAD * 10) /
+                        float(std::chrono::duration_cast<std::chrono::nanoseconds>(ts_end - ts_start).count())) *
+                       1000000000.;
+    std::cout << "Throughput = " << throughput << " predictions/second\n" << std::endl;
 
     std::cout << "Writing hw results to file" << std::endl;
     std::ofstream resultsFile;
     resultsFile.open("tb_data/hw_results.dat", std::ios::trunc);
-    if (resultsFile.is_open()) {   
+    if (resultsFile.is_open()) {
         for (int i = 0; i < num_samples; i++) {
             std::stringstream oline;
             for (int n = 0; n < DATA_SIZE_OUT; n++) {
@@ -101,6 +100,6 @@ int main(int argc, char **argv) {
     } else {
         std::cerr << "Error writing hw results to file" << std::endl;
     }
-    
+
     return EXIT_SUCCESS;
 }

--- a/hls4ml/templates/vitis_accelerator/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/vitis_accelerator/nnet_utils/nnet_types.h
@@ -25,7 +25,7 @@ template <typename T, unsigned N> struct array {
         assert(N == other.size && "Array sizes must match.");
 
         for (unsigned i = 0; i < N; i++) {
-            #pragma HLS UNROLL
+#pragma HLS UNROLL
             data[i] = other[i];
         }
         return *this;


### PR DESCRIPTION
Result of applying `clang-format --style=file -i` on all `.h` , `.hpp` and `.cpp` with clang-format version 14 (version 10 does not like this `.clang-format` file).